### PR TITLE
Prevent squashed people images by using object-fit: cover

### DIFF
--- a/assets/scss/pages/_about.scss
+++ b/assets/scss/pages/_about.scss
@@ -15,6 +15,7 @@ section.people {
       height: 16.25rem;
       border-radius: 50%;
       margin-bottom: $space-xl;
+      object-fit: cover;
     }
 
     .contact-card {


### PR DESCRIPTION
Fixes #17 