### PR TITLE
Addition of schema.org markup for improving SEO

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,23 +24,44 @@
         <link rel="stylesheet" href="{{ .RelPermalink }}">
         {{ end }}
 
+        {{ $aboutDict := dict "@type" "Organization" }}
+        {{ if .Site.Params.contactName }} 
+            {{ $aboutDict = merge (dict "name" .Site.Params.contactName) $aboutDict }}
+        {{ end }}
+        {{ if .Site.Params.contactEmail }} 
+            {{ $aboutDict = merge (dict "email" .Site.Params.contactEmail) $aboutDict }}
+        {{ end }}
+
+        {{ $sameAsSlice := slice }}
+        {{ if .Site.Params.facebookUrl }}
+            {{ $sameAsSlice = $sameAsSlice | append .Site.Params.facebookUrl }}
+        {{ end }}
+        {{ if .Site.Params.twitterUrl }}
+            {{ $sameAsSlice = $sameAsSlice | append .Site.Params.twitterUrl }}
+        {{ end }}
+        {{ if .Site.Params.linkedinUrl }}
+            {{ $sameAsSlice = $sameAsSlice | append .Site.Params.linkedinUrl }}
+        {{ end }}
+        {{ if .Site.Params.blueskyUrl }}
+            {{ $sameAsSlice = $sameAsSlice | append .Site.Params.blueskyUrl }}
+        {{ end }}
+
+        {{ $urlDict := dict }}
+        {{ if .Site.BaseURL }}
+        {{ $urlDict = dict "url" .Site.BaseURL }}
+        {{ else }}
+        {{ $urlDict = dict "url" (absURL "") }}
+        {{ end }}
+
+        {{ $schemaOrg := dict 
+            "@context" "https://schema.org" 
+            "@type" "WebSite" 
+            "about" $aboutDict
+            "sameAs" $sameAsSlice
+        }}
+        {{ $schemaOrg = merge $urlDict $schemaOrg }}
         <script type="application/ld+json">
-        {
-            "@context": "https://schema.org",
-            "@type": "WebSite",
-            "url": {{ .Site.BaseURL }},
-            "about": {
-                "@type": "Organization",
-                "name": "{{ .Site.Params.contactName }}",
-                "email": "{{ .Site.Params.contactEmail }}"
-            },
-            "sameAs": [
-                {{ .Site.Params.facebookUrl }},
-                {{ .Site.Params.twitterUrl }},
-                {{ .Site.Params.linkedinUrl }},
-                {{ .Site.Params.blueskyUrl }}
-            ]
-        }
+        {{ $schemaOrg }}
         </script>
 
         {{ block "head" . }}{{ partial "head-additions.html" . }}{{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,6 +24,25 @@
         <link rel="stylesheet" href="{{ .RelPermalink }}">
         {{ end }}
 
+        <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            "url": {{ .Site.BaseURL }},
+            "about": {
+                "@type": "Organization",
+                "name": "{{ .Site.Params.contactName }}",
+                "email": "{{ .Site.Params.contactEmail }}"
+            },
+            "sameAs": [
+                {{ .Site.Params.facebookUrl }},
+                {{ .Site.Params.twitterUrl }},
+                {{ .Site.Params.linkedinUrl }},
+                {{ .Site.Params.blueskyUrl }}
+            ]
+        }
+        </script>
+
         {{ block "head" . }}{{ partial "head-additions.html" . }}{{ end }}
     </head>
     <body>

--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -2,8 +2,8 @@
 
     {{ partial "breadcrumbs" . }}
 
-    <section class="page-content news">
-        <h1>{{ .Title }}</h1>
+    <section class="page-content news" vocab="https://schema.org/" typeof="SocialMediaPosting">
+        <h1 property="headline">{{ .Title }}</h1>
 
         {{ with .Resources.GetMatch .Params.Image }}
             {{ partial "featured-image.html" . }}
@@ -11,12 +11,14 @@
 
         {{ $dateShort := .PublishDate | time.Format "02/01/2006" }}
         {{ $dateLong := .PublishDate | time.Format ":date_long" }}
-        <time class="news-date" datetime="{{ $dateShort }}">
-            <a class="permalink" href="{{ .RelPermalink }}">
+        <time class="news-date" datetime="{{ $dateShort }}" property="datePublished">
+            <a class="permalink" href="{{ .RelPermalink }}" property="url" >
                 {{ $dateLong }}
             </a>
         </time>
 
-        {{ .Content }}
+        <div property="articleBody">
+            {{ .Content }}
+        </div>
     </section>
 {{ end }}

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,12 +1,16 @@
-<nav aria-label="breadcrumb" class="breadcrumb">
+<nav aria-label="breadcrumb" class="breadcrumb" vocab="https://schema.org/" typeof="BreadcrumbList">
     <ol>
         {{ range .Ancestors.Reverse }}
-        <li>
-            <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        <li property="itemListElement" typeof="ListItem">
+            <a href="{{ .RelPermalink }}" property="item" typeof="WebPage">
+                <span property="name">{{ .LinkTitle }}</span>
+            </a>
         </li>
         {{ end }}
-        <li class="active">
-            <a aria-current="page" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        <li class="active" property="itemListElement" typeof="ListItem">
+            <a aria-current="page" href="{{ .RelPermalink }}" property="item" typeof="WebPage">
+                <span property="name">{{ .LinkTitle }}</span>
+            </a>
         </li>
     </ol>
 </nav>

--- a/layouts/partials/featured-image.html
+++ b/layouts/partials/featured-image.html
@@ -1,10 +1,10 @@
 {{/* Responsive image partial: may need some work! */}}
 <picture class="featured-image">
     {{ with .Resize "640x jpeg" }}
-    <source srcset="{{ .RelPermalink }}" media="(max-width: 640px)">
+    <source srcset="{{ .RelPermalink }}" media="(max-width: 640px)" property="image">
     {{ end }}
     {{ with .Resize "1024x jpeg" }}
-    <source srcset="{{ .RelPermalink }} 2x" media="(max-width: 800px)">
-    <img src="{{ .RelPermalink }}" alt="Featured Image: {{ .Title }}" width="{{ .Width }}" height="{{ .Height }}">
+    <source srcset="{{ .RelPermalink }} 2x" media="(max-width: 800px)" property="image">
+    <img src="{{ .RelPermalink }}" alt="Featured Image: {{ .Title }}" width="{{ .Width }}" height="{{ .Height }}" property="image">
     {{ end }}
 </picture>

--- a/layouts/partials/latest-card.html
+++ b/layouts/partials/latest-card.html
@@ -1,9 +1,9 @@
-<div class="latest-card">
-    <header class="latest-card-header"><a href="{{ .url }}">{{ or (T .id) .title }}</a></header>
-    <div class="latest-card-content">
+<div class="latest-card" vocab="https://schema.org/" typeof="SocialMediaPosting">
+    <header class="latest-card-header" property="headline"><a href="{{ .url }}">{{ or (T .id) .title }}</a></header>
+    <div class="latest-card-content" property="abstract">
         {{ .content | markdownify }}
     </div>
-    <a class="read-more" href="{{ .url }}">
+    <a class="read-more" href="{{ .url }}" property="url">
         {{ i18n "read_more" }}
         <i class="fa-solid fa-fw fa-chevron-right"></i>
     </a>

--- a/layouts/partials/partner-card.html
+++ b/layouts/partials/partner-card.html
@@ -1,17 +1,17 @@
-<div class="partner-card">
+<div class="partner-card" vocab="https://schema.org/" typeof="Organization">
     {{ $url := printf "images/%s" .image }}
     {{ $imgpath := printf "static/%s" $url }}
     {{ if fileExists $imgpath }}
-        <img class="logo" src="{{ $url | relURL }}" alt="{{ .title }} image" />
+        <img class="logo" src="{{ $url | relURL }}" alt="{{ .title }} image" property="image" />
     {{ else }}
         {{ $url := "images/cards-still-1.png" }}
-        <img class="logo" src="{{ $url | relURL }}" alt="{{ .title }} image" />
+        <img class="logo" src="{{ $url | relURL }}" alt="{{ .title }} image" property="image" />
     {{ end }}
     <header class="partner-card-header">
-        <h3><a href="{{ .url }}">{{ .title }}</a></h3>
+        <h3 property="name"><a href="{{ .url }}">{{ .title }}</a></h3>
     </header>
     <div class="partner-card-info">
-        {{ .content | page.RenderString (dict "display" "block")  }}
-        <a class="button-primary" target="_blank" href="{{ .url }}">{{ i18n "go_to" (dict "Name" .title) }}</a>
+        <div property="description">{{ .content | page.RenderString (dict "display" "block")  }}</div>
+        <a class="button-primary" target="_blank" href="{{ .url }}" property="sameAs">{{ i18n "go_to" (dict "Name" .title) }}</a>
     </div>
 </div>

--- a/layouts/partials/people.html
+++ b/layouts/partials/people.html
@@ -4,20 +4,20 @@
 <section class="people paper page-content">
     <div class="person-list">
         {{ range $data }}
-            <div class="person" id="person-{{ .id }}">
+            <div class="person" id="person-{{ .id }}" vocab="https://schema.org/" typeof="Person">
                 {{ $url := printf "images/%s" .image }}
                 {{ $imgpath := printf "static/%s" $url }}
                 {{ if fileExists $imgpath }}
-                    <img class="person-image" src="{{ $url | relURL }}" alt="{{ .name }} image" />
+                    <img class="person-image" src="{{ $url | relURL }}" alt="{{ .name }} image" property="image" />
                 {{ end }}
-                <h2 class="person-name">{{ .name }}</h2>
-                <div class="person-about">
+                <h2 class="person-name" property="name">{{ .name }}</h2>
+                <div class="person-about" property="description">
                     {{ .about | page.RenderString (dict "display" "block") }}
                 </div>
                 {{ if .email }}
                 <div class="contact-card">
                     <header class="contact-name"><a href="mailto:{{ .email }}">{{ .name }}</a></header>
-                    <a class="contact-email" href="mailto:{{ .email }}">
+                    <a class="contact-email" href="mailto:{{ .email }}" property="email">
                         <i class="fa-regular fa-fw fa-envelope"></i>
                         {{ .email }}
                     </a>

--- a/layouts/partials/resource-card.html
+++ b/layouts/partials/resource-card.html
@@ -10,7 +10,7 @@
         {{ end }}
     </div>
     <div class="resource-info">
-        <header class="resource-card-header" property="name"><a href="{{ .url }}" >{{ .title }}</a></header>
+        <header class="resource-card-header" property="name"><a href="{{ .url }}">{{ .title }}</a></header>
         <a class="resource-icon " href="{{ .url }}" property="url"><span class="material-symbols-outlined">{{ .icon }}</span></a>
         <div class="resource-description" property="description">
             {{ .content | page.RenderString (dict "display" "block") }}

--- a/layouts/partials/resource-card.html
+++ b/layouts/partials/resource-card.html
@@ -1,18 +1,18 @@
-<div class="resource-card" id="resource-{{ .id }}">
+<div class="resource-card" id="resource-{{ .id }}" vocab="https://schema.org/" typeof="Service">
     <div class="resource-img">
         {{ $url := printf "images/%s" .image }}
         {{ $imgpath := printf "static/%s" $url }}
         {{ if fileExists $imgpath }}
-            <img class="person-image" src="{{ $url | relURL }}" alt="{{ .title }} image" />
+            <img class="person-image" src="{{ $url | relURL }}" alt="{{ .title }} image" property="image" />
         {{ else }}
             {{ $url := "images/cards-still-1.png" }}
-            <img class="person-image" src="{{ $url | relURL }}" alt="{{ .title }} image" />
+            <img class="person-image" src="{{ $url | relURL }}" alt="{{ .title }} image" property="image" />
         {{ end }}
     </div>
     <div class="resource-info">
-        <header class="resource-card-header"><a href="{{ .url }}">{{ .title }}</a></header>
-        <a class="resource-icon " href="{{ .url }}"><span class="material-symbols-outlined">{{ .icon }}</span></a>
-        <div class="resource-description">
+        <header class="resource-card-header" property="name"><a href="{{ .url }}" >{{ .title }}</a></header>
+        <a class="resource-icon " href="{{ .url }}" property="url"><span class="material-symbols-outlined">{{ .icon }}</span></a>
+        <div class="resource-description" property="description">
             {{ .content | page.RenderString (dict "display" "block") }}
         </div>
         <footer class="links">


### PR DESCRIPTION
Hi,

This PR adds schema.org markup to the EHRI NN websites template in two different forms: data coming from the general config.yml file is enclosed in a JSON-LD (Google preferred format) in the header section and page-specific data is just marked using RDFa. The latter avoids the duplication of information and should ease its maintainability. The main motivation behind this is the improvement of SEO by using structured data, which can lead to a further "understandability" of websites by search engines.

As an example, these additions have been already tested on the EHRI-BE website and the validator output can be seen below for the landing page:
<img width="1920" height="947" alt="imaxe" src="https://github.com/user-attachments/assets/63560c26-3eef-4ce4-afd1-af31ef837bef" />

There are still some limitations to some part of the shown data and the covered pages, but all in all this should serve as an initial and workable approximation.

Best,
Herminio